### PR TITLE
feat: add 'status init' command for first-run config generation

### DIFF
--- a/src/agent/init.rs
+++ b/src/agent/init.rs
@@ -37,20 +37,30 @@ COMMAND_TIMEOUT_SECS=300
 METRICS_INTERVAL_SECS=15
 # METRICS_WEBHOOK=https://example.com/metrics
 
-# ── UI / API credentials (defaults to admin/admin) ───────────────────
-STATUS_PANEL_USERNAME=admin
-STATUS_PANEL_PASSWORD=admin
+# ── UI / API credentials (must be set explicitly before use) ─────────
+STATUS_PANEL_USERNAME=
+STATUS_PANEL_PASSWORD=
 
 # ── Docker ───────────────────────────────────────────────────────────
 # DOCKER_SOCK=unix:///var/run/docker.sock
 # NGINX_CONTAINER=nginx
 
+# ── Compose Agent ────────────────────────────────────────────────────
+# COMPOSE_AGENT_ENABLED=false
+
 # ── Backup / Security ───────────────────────────────────────────────
 # DEPLOYMENT_HASH=
 # BACKUP_PATH=/data/encrypted/backup.tar.gz.cpt
+# TRYDIRECT_IP=
+
+# ── Vault (optional) ────────────────────────────────────────────────
+# VAULT_ADDRESS=http://127.0.0.1:8200
+# VAULT_TOKEN=
 
 # ── Self-update (optional) ──────────────────────────────────────────
 # UPDATE_SERVER_URL=
+# UPDATE_BINARY_URL=
+# UPDATE_EXPECTED_SHA256=
 # UPDATE_STORAGE_PATH=/var/lib/status-panel
 "#;
 
@@ -65,13 +75,15 @@ pub struct InitResult {
 /// Generate default config.json and .env files in the given directory.
 ///
 /// Existing files are never overwritten unless `force` is true.
+/// The .env file is created with restricted permissions (0600) on Unix.
 pub fn generate_default_config(dir: &Path, force: bool) -> Result<InitResult> {
     let config_path = dir.join("config.json");
     let env_path = dir.join(".env");
 
     let config_created =
         write_if_absent(&config_path, DEFAULT_CONFIG, force).context("writing config.json")?;
-    let env_created = write_if_absent(&env_path, DEFAULT_ENV, force).context("writing .env")?;
+    let env_created =
+        write_if_absent_secure(&env_path, DEFAULT_ENV, force).context("writing .env")?;
 
     if config_created {
         info!(path = %config_path.display(), "created default config.json");
@@ -88,14 +100,66 @@ pub fn generate_default_config(dir: &Path, force: bool) -> Result<InitResult> {
     })
 }
 
-/// Write `content` to `path` if the file does not exist or `force` is true.
+/// Write `content` to `path` atomically if the file does not exist.
+/// When `force` is true, truncates and overwrites.
 /// Returns `true` when the file was actually written.
 fn write_if_absent(path: &Path, content: &str, force: bool) -> Result<bool> {
-    if path.exists() && !force {
-        return Ok(false);
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    if force {
+        std::fs::write(path, content)?;
+        return Ok(true);
     }
+
+    // Atomic create: fails with AlreadyExists if file is present (no TOCTOU)
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut f) => {
+            f.write_all(content.as_bytes())?;
+            Ok(true)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Like `write_if_absent` but sets 0600 permissions on Unix (for secret-bearing files).
+fn write_if_absent_secure(path: &Path, content: &str, force: bool) -> Result<bool> {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    if force {
+        write_with_restricted_perms(path, content)?;
+        return Ok(true);
+    }
+
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut f) => {
+            f.write_all(content.as_bytes())?;
+            drop(f);
+            set_restricted_perms(path);
+            Ok(true)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn write_with_restricted_perms(path: &Path, content: &str) -> Result<()> {
     std::fs::write(path, content)?;
-    Ok(true)
+    set_restricted_perms(path);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_restricted_perms(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_restricted_perms(_path: &Path) {
+    // No-op on non-Unix platforms
 }
 
 #[cfg(test)]
@@ -159,5 +223,35 @@ mod tests {
         assert_eq!(cfg.domain.as_deref(), Some("example.com"));
         assert_eq!(cfg.reqdata.email, "admin@example.com");
         assert!(!cfg.compose_agent_enabled);
+    }
+
+    #[test]
+    fn test_env_contains_all_documented_vars() {
+        assert!(DEFAULT_ENV.contains("AGENT_ID="));
+        assert!(DEFAULT_ENV.contains("AGENT_TOKEN="));
+        assert!(DEFAULT_ENV.contains("DASHBOARD_URL="));
+        assert!(DEFAULT_ENV.contains("STATUS_PANEL_USERNAME="));
+        assert!(DEFAULT_ENV.contains("STATUS_PANEL_PASSWORD="));
+        assert!(DEFAULT_ENV.contains("COMPOSE_AGENT_ENABLED"));
+        assert!(DEFAULT_ENV.contains("VAULT_ADDRESS"));
+        assert!(DEFAULT_ENV.contains("VAULT_TOKEN"));
+        assert!(DEFAULT_ENV.contains("DEPLOYMENT_HASH"));
+        assert!(DEFAULT_ENV.contains("UPDATE_SERVER_URL"));
+        assert!(DEFAULT_ENV.contains("UPDATE_STORAGE_PATH"));
+        // Credentials must not have default values baked in
+        assert!(DEFAULT_ENV.contains("STATUS_PANEL_USERNAME=\n"));
+        assert!(DEFAULT_ENV.contains("STATUS_PANEL_PASSWORD=\n"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_env_file_has_restricted_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        generate_default_config(dir.path(), false).unwrap();
+
+        let meta = std::fs::metadata(dir.path().join(".env")).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {:o}", mode);
     }
 }

--- a/src/agent/init.rs
+++ b/src/agent/init.rs
@@ -1,0 +1,163 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use tracing::info;
+
+/// Default config.json content with sensible defaults.
+const DEFAULT_CONFIG: &str = r#"{
+    "ssl": "letsencrypt",
+    "domain": "example.com",
+    "reqdata": {
+        "email": "admin@example.com"
+    },
+    "apps_info": null,
+    "subdomains": {},
+    "compose_agent_enabled": false,
+    "control_plane": "status_panel"
+}
+"#;
+
+/// Default .env content with documented variables.
+const DEFAULT_ENV: &str = r#"# Status Panel Agent – Environment Configuration
+# Docs: https://github.com/trydirect/status
+
+# ── Agent Identity (set after running `status register`) ─────────────
+AGENT_ID=
+AGENT_TOKEN=
+
+# ── Dashboard / Stacker Server ───────────────────────────────────────
+DASHBOARD_URL=https://stacker.try.direct
+
+# ── Polling (pull-based command loop) ────────────────────────────────
+POLLING_TIMEOUT_SECS=30
+POLLING_BACKOFF_SECS=5
+COMMAND_TIMEOUT_SECS=300
+
+# ── Metrics ──────────────────────────────────────────────────────────
+METRICS_INTERVAL_SECS=15
+# METRICS_WEBHOOK=https://example.com/metrics
+
+# ── UI / API credentials (defaults to admin/admin) ───────────────────
+STATUS_PANEL_USERNAME=admin
+STATUS_PANEL_PASSWORD=admin
+
+# ── Docker ───────────────────────────────────────────────────────────
+# DOCKER_SOCK=unix:///var/run/docker.sock
+# NGINX_CONTAINER=nginx
+
+# ── Backup / Security ───────────────────────────────────────────────
+# DEPLOYMENT_HASH=
+# BACKUP_PATH=/data/encrypted/backup.tar.gz.cpt
+
+# ── Self-update (optional) ──────────────────────────────────────────
+# UPDATE_SERVER_URL=
+# UPDATE_STORAGE_PATH=/var/lib/status-panel
+"#;
+
+/// Result of the init operation, indicating which files were created.
+pub struct InitResult {
+    pub config_created: bool,
+    pub env_created: bool,
+    pub config_path: String,
+    pub env_path: String,
+}
+
+/// Generate default config.json and .env files in the given directory.
+///
+/// Existing files are never overwritten unless `force` is true.
+pub fn generate_default_config(dir: &Path, force: bool) -> Result<InitResult> {
+    let config_path = dir.join("config.json");
+    let env_path = dir.join(".env");
+
+    let config_created =
+        write_if_absent(&config_path, DEFAULT_CONFIG, force).context("writing config.json")?;
+    let env_created = write_if_absent(&env_path, DEFAULT_ENV, force).context("writing .env")?;
+
+    if config_created {
+        info!(path = %config_path.display(), "created default config.json");
+    }
+    if env_created {
+        info!(path = %env_path.display(), "created default .env");
+    }
+
+    Ok(InitResult {
+        config_created,
+        env_created,
+        config_path: config_path.display().to_string(),
+        env_path: env_path.display().to_string(),
+    })
+}
+
+/// Write `content` to `path` if the file does not exist or `force` is true.
+/// Returns `true` when the file was actually written.
+fn write_if_absent(path: &Path, content: &str, force: bool) -> Result<bool> {
+    if path.exists() && !force {
+        return Ok(false);
+    }
+    std::fs::write(path, content)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_creates_both_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = generate_default_config(dir.path(), false).unwrap();
+
+        assert!(result.config_created);
+        assert!(result.env_created);
+
+        let config_content = std::fs::read_to_string(dir.path().join("config.json")).unwrap();
+        assert!(config_content.contains("\"domain\""));
+        assert!(config_content.contains("\"reqdata\""));
+
+        let env_content = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(env_content.contains("AGENT_ID="));
+        assert!(env_content.contains("DASHBOARD_URL="));
+    }
+
+    #[test]
+    fn test_generate_skips_existing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), "existing").unwrap();
+
+        let result = generate_default_config(dir.path(), false).unwrap();
+
+        assert!(!result.config_created);
+        assert!(result.env_created);
+
+        // Original file untouched
+        let content = std::fs::read_to_string(dir.path().join("config.json")).unwrap();
+        assert_eq!(content, "existing");
+    }
+
+    #[test]
+    fn test_generate_force_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), "old").unwrap();
+
+        let result = generate_default_config(dir.path(), true).unwrap();
+
+        assert!(result.config_created);
+        let content = std::fs::read_to_string(dir.path().join("config.json")).unwrap();
+        assert!(content.contains("\"domain\""));
+    }
+
+    #[test]
+    fn test_default_config_is_valid_json() {
+        let parsed: serde_json::Value = serde_json::from_str(DEFAULT_CONFIG).unwrap();
+        assert_eq!(parsed["domain"], "example.com");
+        assert_eq!(parsed["reqdata"]["email"], "admin@example.com");
+    }
+
+    #[test]
+    fn test_default_config_deserializes_to_config() {
+        let cfg: super::super::config::Config = serde_json::from_str(DEFAULT_CONFIG).unwrap();
+        assert_eq!(cfg.domain.as_deref(), Some("example.com"));
+        assert_eq!(cfg.reqdata.email, "admin@example.com");
+        assert!(!cfg.compose_agent_enabled);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2,5 +2,6 @@ pub mod backup;
 pub mod config;
 pub mod daemon;
 pub mod docker;
+pub mod init;
 pub mod registration;
 pub mod watchdog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use dotenvy::dotenv;
 use status_panel::{agent, commands, comms, monitoring, utils};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use tracing::info;
 
@@ -185,6 +185,12 @@ enum Commands {
         #[arg(long)]
         server: Option<String>,
     },
+    /// Generate default config.json and .env files in the current directory
+    Init {
+        /// Overwrite existing files
+        #[arg(long, default_value_t = false)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -231,6 +237,15 @@ async fn main() -> Result<()> {
 
     match args.command {
         Some(Commands::Serve { port, with_ui }) => {
+            if !std::path::Path::new(&args.config).exists() {
+                eprintln!();
+                eprintln!("  Config file not found: {}", args.config);
+                eprintln!();
+                eprintln!("  Run 'status init' to generate a default configuration,");
+                eprintln!("  or specify a custom path with --config <path>");
+                eprintln!();
+                std::process::exit(1);
+            }
             if with_ui {
                 info!("Starting local API server with UI on port {port}");
             } else {
@@ -400,8 +415,50 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        Some(Commands::Init { force }) => {
+            let cwd = std::env::current_dir().context("could not determine current directory")?;
+            let result = agent::init::generate_default_config(&cwd, force)?;
+
+            println!();
+            if result.config_created {
+                println!("  ✔ Created {}", result.config_path);
+            } else {
+                println!(
+                    "  • Skipped {} (already exists, use --force to overwrite)",
+                    result.config_path
+                );
+            }
+            if result.env_created {
+                println!("  ✔ Created {}", result.env_path);
+            } else {
+                println!(
+                    "  • Skipped {} (already exists, use --force to overwrite)",
+                    result.env_path
+                );
+            }
+
+            println!();
+            println!("Next steps:");
+            println!("  1. Edit config.json — set your domain and email");
+            println!("  2. Edit .env       — set AGENT_ID, AGENT_TOKEN, DASHBOARD_URL");
+            println!("  3. Run:  status                    # start daemon");
+            println!("     or:   status serve --port 5000  # start API server");
+            println!();
+            println!("  To register with Stacker:");
+            println!("     status register --purchase-token <TOKEN> --stack-id <ID>");
+            println!();
+        }
         None => {
             // Default: run the agent daemon
+            if !std::path::Path::new(&args.config).exists() {
+                eprintln!();
+                eprintln!("  Config file not found: {}", args.config);
+                eprintln!();
+                eprintln!("  Run 'status init' to generate a default configuration,");
+                eprintln!("  or specify a custom path with --config <path>");
+                eprintln!();
+                std::process::exit(1);
+            }
             if args.compose_mode {
                 info!("Starting compose-agent daemon mode");
                 // Set CONTROL_PLANE environment variable for identification

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,71 @@
 use dotenvy::dotenv;
 use status_panel::{agent, commands, comms, monitoring, utils};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing::info;
 
 /// Application version from Cargo.toml
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+
+/// Check that `path` points to a readable file. Prints a friendly error and
+/// exits if the file is missing, is not a regular file, or is not readable.
+fn ensure_config_file(path: &str) {
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_file() => {
+            // Verify readability
+            if let Err(err) = std::fs::File::open(path) {
+                if err.kind() == std::io::ErrorKind::PermissionDenied {
+                    eprintln!();
+                    eprintln!("  Config file is not readable: {path}");
+                    eprintln!();
+                    eprintln!("  Check the file permissions and try again.");
+                    eprintln!();
+                    std::process::exit(1);
+                }
+                eprintln!();
+                eprintln!("  Cannot open config file: {path}");
+                eprintln!("  Error: {err}");
+                eprintln!();
+                std::process::exit(1);
+            }
+        }
+        Ok(_) => {
+            eprintln!();
+            eprintln!("  Config path is not a regular file: {path}");
+            eprintln!();
+            eprintln!("  Run 'status init' to generate a default configuration,");
+            eprintln!("  or specify a valid file with --config <path>");
+            eprintln!();
+            std::process::exit(1);
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!();
+            eprintln!("  Config file not found: {path}");
+            eprintln!();
+            eprintln!("  Run 'status init' to generate a default configuration,");
+            eprintln!("  or specify a custom path with --config <path>");
+            eprintln!();
+            std::process::exit(1);
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!();
+            eprintln!("  Config file is not readable: {path}");
+            eprintln!();
+            eprintln!("  Check the file permissions and try again.");
+            eprintln!();
+            std::process::exit(1);
+        }
+        Err(err) => {
+            eprintln!();
+            eprintln!("  Cannot access config file: {path}");
+            eprintln!("  Error: {err}");
+            eprintln!();
+            std::process::exit(1);
+        }
+    }
+}
 
 /// Print startup banner with version and system info
 fn print_banner() {
@@ -237,15 +295,7 @@ async fn main() -> Result<()> {
 
     match args.command {
         Some(Commands::Serve { port, with_ui }) => {
-            if !std::path::Path::new(&args.config).exists() {
-                eprintln!();
-                eprintln!("  Config file not found: {}", args.config);
-                eprintln!();
-                eprintln!("  Run 'status init' to generate a default configuration,");
-                eprintln!("  or specify a custom path with --config <path>");
-                eprintln!();
-                std::process::exit(1);
-            }
+            ensure_config_file(&args.config);
             if with_ui {
                 info!("Starting local API server with UI on port {port}");
             } else {
@@ -416,8 +466,16 @@ async fn main() -> Result<()> {
             }
         }
         Some(Commands::Init { force }) => {
-            let cwd = std::env::current_dir().context("could not determine current directory")?;
-            let result = agent::init::generate_default_config(&cwd, force)?;
+            // Derive output directory from --config path (defaults to current dir)
+            let config_path = std::path::Path::new(&args.config);
+            let dir = config_path
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| {
+                    std::env::current_dir().expect("could not determine current directory")
+                });
+            let result = agent::init::generate_default_config(&dir, force)?;
 
             println!();
             if result.config_created {
@@ -450,15 +508,7 @@ async fn main() -> Result<()> {
         }
         None => {
             // Default: run the agent daemon
-            if !std::path::Path::new(&args.config).exists() {
-                eprintln!();
-                eprintln!("  Config file not found: {}", args.config);
-                eprintln!();
-                eprintln!("  Run 'status init' to generate a default configuration,");
-                eprintln!("  or specify a custom path with --config <path>");
-                eprintln!();
-                std::process::exit(1);
-            }
+            ensure_config_file(&args.config);
             if args.compose_mode {
                 info!("Starting compose-agent daemon mode");
                 // Set CONTROL_PLANE environment variable for identification


### PR DESCRIPTION
## Summary

Improves the first-run experience after installing the Status Panel agent via `curl`.

### Problem
Running `status` without a config file shows a cryptic stack trace:
```
Error: reading config file
Caused by: No such file or directory (os error 2)
Stack backtrace: ...
```

### Solution

**New `status init` subcommand** that generates default `config.json` and `.env` files:
```
$ status init
  ✔ Created ./config.json
  ✔ Created ./.env

Next steps:
  1. Edit config.json — set your domain and email
  2. Edit .env       — set AGENT_ID, AGENT_TOKEN, DASHBOARD_URL
  3. Run:  status                    # start daemon
     or:   status serve --port 5000  # start API server
```

**Friendly error when config is missing** (daemon and serve modes):
```
  Config file not found: config.json

  Run 'status init' to generate a default configuration,
  or specify a custom path with --config <path>
```

### Details
- `--force` flag to overwrite existing files
- Existing files are never overwritten by default
- `.env` includes all documented env vars with descriptions
- 5 new unit tests

### Files changed
- `src/agent/init.rs` — new module with config generation logic
- `src/agent/mod.rs` — register init module
- `src/main.rs` — Init subcommand + friendly missing-config errors