### PR TITLE
release: v0.1.7 — security hardening (OWASP Top 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.1.7 — 2026-04-10
+### Security — OWASP Top 10 Hardening
+
+This is a **security release** addressing 6 Critical and 5 High severity findings from a comprehensive OWASP Top 10 audit.
+
+#### A01: Broken Access Control
+- **No default credentials** — `Credentials::from_env()` now returns an error when `STATUS_PANEL_USERNAME` / `STATUS_PANEL_PASSWORD` are unset; no admin/admin backdoor
+- **Container routes require auth** — `/restart/{name}`, `/stop/{name}`, `/pause/{name}` now enforce session authentication
+- **SSL routes require auth** — `/enable_ssl`, `/disable_ssl` now enforce session authentication
+- **AGENT_ID enforced** — `validate_agent_id` rejects requests when `AGENT_ID` env var is unset or empty
+
+#### A02: Cryptographic Failures
+- **Secure session cookies** — `Set-Cookie` now includes `Secure; SameSite=Strict; HttpOnly`
+
+#### A03: Injection
+- **Certbot command injection prevented** — email and domain values validated against shell metacharacters before `exec_in_container`
+- **Daemon shell fallback validated** — unrecognised commands now pass through `CommandValidator` before execution
+- New `security::validation` module with `is_safe_shell_value()`, `is_valid_domain()`, `is_valid_email()`, `is_safe_update_url()`
+
+#### A04: Insecure Design
+- **Session TTL** — `SessionStore` now tracks creation timestamps; `cleanup_expired(duration)` removes stale sessions
+
+#### A05: Security Misconfiguration
+- **Default bind address is 127.0.0.1** — server no longer binds `0.0.0.0` by default; explicit `--bind 0.0.0.0` required for all-interfaces
+
+#### A07: Identification and Authentication Failures
+- **Logout invalidates session** — `logout_handler` extracts cookie, calls `delete_session`, and sets `Max-Age=0`
+
+#### A08: Software and Data Integrity Failures
+- **HTTPS enforced for self-update** — `start_update_job` rejects HTTP URLs
+- **SHA256 always computed** — hash is calculated on every download; warns if `UPDATE_EXPECTED_SHA256` is not set
+
+### Added
+- `status init` command — generates default `config.json` and `.env` template on first run
+- Friendly error message when `config.json` is missing (replaces stack trace)
+- 12 automated OWASP security tests (`tests/owasp_security.rs`)
+
+### Fixed
+- RUSTSEC-2026-0049 — upgraded `rustls-webpki` 0.103.8 → 0.103.10
+
 ## 0.1.6 — 2026-04-08
 ### Added — Kata Containers Runtime Support
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2077,6 +2077,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustc_version_runtime",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "status-panel"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# Pin minimum rustls-webpki to fix RUSTSEC-2026-0049 (CRL matching logic)
+rustls-webpki = ">=0.103.10"
 ring = "0.17"
 bytes = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "status-panel"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl -sSfL https://raw.githubusercontent.com/trydirect/status/master/install.sh 
 Pin a specific version or choose a custom directory:
 
 ```bash
-VERSION=v0.1.4 curl -sSfL https://raw.githubusercontent.com/trydirect/status/master/install.sh | sh
+VERSION=v0.1.7 curl -sSfL https://raw.githubusercontent.com/trydirect/status/master/install.sh | sh
 INSTALL_DIR=~/.local/bin curl -sSfL https://raw.githubusercontent.com/trydirect/status/master/install.sh | sh
 ```
 
@@ -50,6 +50,7 @@ status --version
 ## CLI Commands
 
 ```
+status init                               Generate default config.json and .env
 status serve [--port 5000] [--with-ui]   Start the HTTP API server
 status containers                         List all Docker containers
 status health [name]                      Check container or stack health
@@ -62,6 +63,29 @@ status metrics [--json]                   Show CPU, memory, disk usage
 status update check                       Check for new versions
 status update apply [--version V]         Download and verify an update
 status update rollback                    Roll back to previous version
+```
+
+## First Run
+
+After installing, generate the default configuration files:
+
+```bash
+status init                      # creates config.json and .env in current directory
+status init --config /etc/status # custom path
+```
+
+Edit `.env` to set **required** credentials before starting:
+
+```bash
+STATUS_PANEL_USERNAME=myuser
+STATUS_PANEL_PASSWORD=strong-secret
+AGENT_ID=my-server-01
+```
+
+Then start the agent:
+
+```bash
+status --config config.json
 ```
 
 ## Running Modes
@@ -158,11 +182,16 @@ The agent accepts signed commands from the Stacker dashboard covering the full l
 
 ## Security
 
+- **No default credentials** — `STATUS_PANEL_USERNAME` and `STATUS_PANEL_PASSWORD` must be set; login is disabled until configured
 - **HMAC-SHA256** request signing with `AGENT_TOKEN`
 - **Replay protection** via `X-Request-Id` tracking
 - **Rate limiting** per agent
+- **Session security** — HttpOnly + Secure + SameSite=Strict cookies; server-side session invalidation on logout; TTL-based cleanup
 - **Command validation** — conservative allowlist, blocked shells and metacharacters
+- **Injection prevention** — all shell-interpolated values (email, domains, container names) validated against metacharacters
 - **Exec sandboxing** — dangerous commands (`rm -rf /`, `mkfs`, `shutdown`, etc.) are blocked
+- **Localhost by default** — API server binds `127.0.0.1`; explicit `--bind 0.0.0.0` required for external access
+- **HTTPS-only updates** — self-update rejects HTTP download URLs; SHA256 verification on every download
 - **Audit logging** — all auth attempts and scope denials recorded
 - **Vault integration** — secrets and configs stored securely, never in plaintext
 
@@ -170,11 +199,14 @@ The agent accepts signed commands from the Stacker dashboard covering the full l
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `AGENT_ID` | Unique agent identifier |
+| `STATUS_PANEL_USERNAME` | **Required.** Login username |
+| `STATUS_PANEL_PASSWORD` | **Required.** Login password |
+| `AGENT_ID` | **Required.** Unique agent identifier (protects API endpoints) |
 | `AGENT_TOKEN` | Authentication token for signed requests |
 | `DASHBOARD_URL` | Remote dashboard URL |
 | `VAULT_ADDRESS` | HashiCorp Vault server URL |
 | `UPDATE_SERVER_URL` | Remote update server for version checks |
+| `UPDATE_EXPECTED_SHA256` | Expected SHA256 hash for self-update binary |
 | `COMPOSE_AGENT_ENABLED` | Enable compose-agent mode |
 | `METRICS_INTERVAL_SECS` | Metrics collection interval |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,47 @@ The project maintainers will then work with you to resolve any issues where requ
 
 ---
 
+## Authentication Hardening (v0.1.7+)
+
+### Credential Configuration
+
+The agent has **no default credentials**. Authentication is disabled until you explicitly configure:
+
+```bash
+STATUS_PANEL_USERNAME=your-username
+STATUS_PANEL_PASSWORD=your-strong-password
+```
+
+If these environment variables are not set:
+- Login returns `503 Service Unavailable`
+- A warning is logged on every login attempt
+- Run `status init` to generate a `.env` template
+
+### Agent ID Protection
+
+The `AGENT_ID` environment variable must be set to protect API endpoints (`/api/self/*`, `/api/v1/*`). When unset, these endpoints return `401 Unauthorized`.
+
+### Session Security
+
+- Sessions are stored in-memory with creation timestamps
+- `cleanup_expired(duration)` removes sessions older than the TTL
+- Logout invalidates the session server-side and clears the cookie
+- Cookies use `HttpOnly; Secure; SameSite=Strict` attributes
+- `Max-Age=0` is set on logout to prevent stale cookies
+
+### Bind Address
+
+The API server defaults to `127.0.0.1` (localhost only). To expose on all interfaces, explicitly pass `--bind 0.0.0.0`. This prevents accidental exposure on public networks.
+
+### Self-Update Integrity
+
+- Update downloads require HTTPS — HTTP URLs are rejected
+- SHA256 hash is computed on every download
+- If `UPDATE_EXPECTED_SHA256` is set, hash must match or the update fails
+- If not set, a warning is logged with the computed hash for manual verification
+
+---
+
 ## Vault Integration Security
 
 ### Token Rotation Best Practices


### PR DESCRIPTION
## v0.1.7 Security Release

### Security — OWASP Top 10 Hardening (6 Critical + 5 High)

**A01: Broken Access Control**
- No default credentials — `from_env()` returns error when env vars unset
- Container & SSL routes require session authentication
- `AGENT_ID` enforced — rejects when unset

**A02: Cryptographic Failures**
- Session cookies: `Secure; SameSite=Strict; HttpOnly`

**A03: Injection**
- Certbot email/domain injection prevented via `security::validation` module
- Daemon shell fallback now uses `CommandValidator`

**A04: Insecure Design**
- Session TTL with `cleanup_expired(duration)`

**A05: Security Misconfiguration**
- Default bind address changed to `127.0.0.1`

**A07: Authentication Failures**
- Logout properly invalidates session and clears cookie

**A08: Data Integrity**
- Self-update enforces HTTPS; SHA256 always computed

### Added
- `status init` command — generates config.json and .env template
- 12 automated OWASP security tests

### Fixed
- RUSTSEC-2026-0049 (rustls-webpki 0.103.8 → 0.103.10)

### Docs
- CHANGELOG, README, SECURITY.md updated with security guidance
- Credentials and AGENT_ID marked as **required** in env var table
